### PR TITLE
Update MPFR.cmake

### DIFF
--- a/deps/MPFR/MPFR.cmake
+++ b/deps/MPFR/MPFR.cmake
@@ -25,8 +25,8 @@ else ()
     endif ()
 
     ExternalProject_Add(dep_MPFR
-        URL https://www.mpfr.org/mpfr-current/mpfr-4.2.1.tar.bz2
-        URL_HASH SHA256=b9df93635b20e4089c29623b19420c4ac848a1b29df1cfd59f26cab0d2666aa0
+        URL https://www.mpfr.org/mpfr-4.2.1/mpfr-4.2.1.tar.xz
+        URL_HASH SHA256=277807353a6726978996945af13e52829e3abd7a9a5b7fb2793894e18f1fcbb2
         DOWNLOAD_DIR ${DEP_DOWNLOAD_DIR}/MPFR
         BUILD_IN_SOURCE ON
         CONFIGURE_COMMAND autoreconf -f -i && 


### PR DESCRIPTION
URL has changed since release of 4.2.2

# Description

<!--
> Please provide a summary of the changes made in this PR. Include details such as:
  > * What issue does this PR address or fix?
  > * What new features or enhancements does this PR introduce?
  > * Are there any breaking changes or dependencies that need to be considered?
-->
I've been trying to  build the Linux version of your slicer but was getting errors.
This one I could solve but there are other compiler errors I don't know how to fix.

# Screenshots/Recordings/Graphs
<!--
> Please attach relevant screenshots to showcase the UI changes.
> Please attach images that can help explain the changes.
-->
N/A

## Tests
<!--
> Please describe the tests that you have conducted to verify the changes made in this PR.
-->
MPFR now compiles but other errors cause the build to fail further into the build process. It may be becasue a new GCC version has added further error checking.

I am Running Debian 13 (Trixie), GCC 14.2.0-17